### PR TITLE
fix: Resolve Android resource linking error

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,11 +6,9 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
-        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.NetSpeed"
+        android:theme="@style/Theme.AirHockeyNeo"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
@@ -23,8 +21,7 @@
         </activity>
         <activity
             android:name=".GameActivity"
-            android:screenOrientation="portrait"
-            android:theme="@style/Theme.AppCompat.NoActionBar" />
+            android:screenOrientation="portrait" />
     </application>
 
 </manifest>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">NetSpeed</string>
+    <string name="app_name">Air Hockey Neo</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,17 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.NetSpeed" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/black</item>
-        <item name="colorPrimaryVariant">@color/black</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/black</item>
-        <item name="colorSecondaryVariant">@color/black</item>
-        <item name="colorOnSecondary">@color/white</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
-        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+    <style name="Theme.AirHockeyNeo" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- We are a full-screen game, so we don't need many theme attributes. -->
+        <!-- Set the status bar color to black. -->
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/black</item>
     </style>
 </resources>


### PR DESCRIPTION
This commit fixes a build failure caused by 'Android resource linking failed'.

The root cause was twofold:
1. A theme conflict between the application's base theme and the GameActivity's theme. This was resolved by creating a single, consistent NoActionBar theme for the entire application.
2. Missing mipmap icon resources (`ic_launcher` and `ic_launcher_round`) that were referenced in the AndroidManifest.xml. This was resolved by removing the `android:icon` and `android:roundIcon` attributes from the manifest.

These changes should allow the project to build successfully.